### PR TITLE
Draft

### DIFF
--- a/src/pages/[lang]/blog/[...id].astro
+++ b/src/pages/[lang]/blog/[...id].astro
@@ -5,7 +5,7 @@ import { type Lang, useTranslations } from "@/i18n";
 import Layout from "@/layouts/Article.astro";
 
 export async function getStaticPaths() {
-	const posts = await getCollection("blog");
+	const posts = await getCollection("blog", ({ data }) => !data.draft);
 
 	return posts.map((post) => {
 		const [lang, ...id] = post.id.split("/");

--- a/src/pages/[lang]/rss.xml.js
+++ b/src/pages/[lang]/rss.xml.js
@@ -15,8 +15,8 @@ export async function GET(context) {
 			? SITE_DESCRIPTION
 			: SITE_DESCRIPTION[locale];
 
-	const posts = await getCollection("blog", ({ id }) => {
-		return id.split("/")[0] === locale;
+	const posts = await getCollection("blog", ({ id, data }) => {
+		return !data.draft && id.split("/")[0] === locale;
 	});
 	posts.sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
 

--- a/src/pages/ar/page.mdx
+++ b/src/pages/ar/page.mdx
@@ -96,7 +96,7 @@ src/
 import { getCollection } from "astro:content";
 
 export async function getStaticPaths() {
-  const posts = await getCollection("blog");
+  const posts = await getCollection("blog", ({ data }) => !data.draft)
 
   return posts.map((post) => {
     const [lang, ...id] = post.id.split("/");

--- a/src/pages/en/page.mdx
+++ b/src/pages/en/page.mdx
@@ -96,7 +96,7 @@ src/
 import { getCollection } from "astro:content";
 
 export async function getStaticPaths() {
-  const posts = await getCollection("blog");
+  const posts = await getCollection("blog", ({ data }) => !data.draft)
 
   return posts.map((post) => {
     const [lang, ...id] = post.id.split("/");

--- a/src/pages/es/page.mdx
+++ b/src/pages/es/page.mdx
@@ -96,7 +96,7 @@ src/
 import { getCollection } from "astro:content";
 
 export async function getStaticPaths() {
-  const posts = await getCollection("blog");
+  const posts = await getCollection("blog", ({ data }) => !data.draft)
 
   return posts.map((post) => {
     const [lang, ...id] = post.id.split("/");

--- a/src/pages/ja/page.mdx
+++ b/src/pages/ja/page.mdx
@@ -96,7 +96,7 @@ src/
 import { getCollection } from "astro:content";
 
 export async function getStaticPaths() {
-  const posts = await getCollection("blog");
+  const posts = await getCollection("blog", ({ data }) => !data.draft)
 
   return posts.map((post) => {
     const [lang, ...id] = post.id.split("/");

--- a/src/pages/zh-cn/page.mdx
+++ b/src/pages/zh-cn/page.mdx
@@ -96,7 +96,7 @@ src/
 import { getCollection } from "astro:content";
 
 export async function getStaticPaths() {
-  const posts = await getCollection("blog");
+  const posts = await getCollection("blog", ({ data }) => !data.draft)
 
   return posts.map((post) => {
     const [lang, ...id] = post.id.split("/");


### PR DESCRIPTION
This pull request focuses on filtering out draft blog posts from being included in the static paths generation and RSS feed. The changes ensure that only non-draft blog posts are processed. 

Filtering out draft posts:

* `src/pages/[lang]/blog/[...id].astro`: Updated the `getCollection` call to exclude draft posts by adding a filter condition. ([src/pages/[lang]/blog/[...id].astroL8-R8](diffhunk://#diff-f966ccf1f028c6d3da61d9b9fc70ee63a012f8779f491762affb60947240201dL8-R8))
* `src/pages/[lang]/rss.xml.js`: Modified the `getCollection` call to exclude draft posts and ensure only posts from the specified locale are included. ([src/pages/[lang]/rss.xml.jsL18-R19](diffhunk://#diff-5fa94f0e0f6467605d9ad4b991c68799f4157ec5376a07585389675c44f780b8L18-R19))
* `src/pages/ar/page.mdx`, `src/pages/en/page.mdx`, `src/pages/es/page.mdx`, `src/pages/ja/page.mdx`, `src/pages/zh-cn/page.mdx`: Updated the `getCollection` calls in these files to filter out draft posts. [[1]](diffhunk://#diff-a6baaf9aa5622a635abf91240031d44473e28078915c623c2dcaf0ca9ec5c203L99-R99) [[2]](diffhunk://#diff-4d77c9fc0516c0d57ede21fe1e68debe8c309b6382a23d911f3098f43e1d3ca0L99-R99) [[3]](diffhunk://#diff-7138661f764887bc629537652769175319dd0bb5f2c5c07f231a6dd82dc4c52cL99-R99) [[4]](diffhunk://#diff-8feb276a85d85350d426ff9ea267279d15aa4bd43240d818d8f4f9f00c94a79bL99-R99) [[5]](diffhunk://#diff-4a5f88d33de2b5893d51c65e999d6b5a1475616c0441bf7e4df5c1c877c628f1L99-R99)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Blog pages now display only published posts by automatically filtering out drafts.
  - The RSS feed has been updated to exclude draft posts, ensuring only finalized content is shown to readers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->