### PR TITLE
fix: Update admin.astro to pinned version

### DIFF
--- a/src/pages/admin.astro
+++ b/src/pages/admin.astro
@@ -50,6 +50,6 @@
 	</head>
 	<body>
 		<!-- <script is:inline src="https://unpkg.com/decap-cms@^3.4.0/dist/decap-cms.js"></script> -->
-		<script is:inline src="https://unpkg.com/@sveltia/cms/dist/sveltia-cms.js"></script>
+		<script is:inline src="https://unpkg.com/@sveltia/cms@0.61.0/dist/sveltia-cms.js"></script>
 	</body>
 </html>


### PR DESCRIPTION
This pull request makes a small update to the `src/pages/admin.astro` file, specifying an explicit version (`0.61.0`) for the `@sveltia/cms` script import to ensure consistent and predictable builds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned the admin CMS script to a specific version to ensure consistent behavior across environments.
  * Improves stability and predictability of the admin interface, reducing risk of sudden UI changes or regressions.
  * Enhances reliability of updates and simplifies troubleshooting if issues arise.
  * No functional changes expected for end-users; no action required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->